### PR TITLE
Feature/ranked bingo tiles

### DIFF
--- a/src/components/RankSelector.js
+++ b/src/components/RankSelector.js
@@ -20,7 +20,7 @@ class RankSelector extends React.Component {
                 <option value="2">Silver</option>
                 <option value="3">Gold</option>
                 <option value="4">Platinum</option>
-                <option value="5">Diamon</option>
+                <option value="5">Diamond</option>
                 <option value="6">Champ</option>
                 <option value="7">Grand Champ</option>
                 <option value="8">Celebrity</option>

--- a/src/components/RankSelector.js
+++ b/src/components/RankSelector.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+class RankSelector extends React.Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            value: 0
+        }
+    }
+    updateRank = (event) => {
+        this.setState({ value: event.target.value })
+        this.props.onRankSelected(event.target.value);
+    }
+
+    render() {
+        return(
+            <select onChange={this.updateRank}>
+                <option value="0" selected>(Select your Rank)</option>
+                <option value="1">Bronze</option>
+                <option value="2">Silver</option>
+                <option value="3">Gold</option>
+                <option value="4">Platinum</option>
+                <option value="5">Diamon</option>
+                <option value="6">Champ</option>
+                <option value="7">Grand Champ</option>
+                <option value="8">Celebrity</option>
+                <option value="9">Pro</option>
+            </select>
+        );
+    }
+}
+
+export default RankSelector

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -3,6 +3,8 @@ import GitHubLogo from './images/githubLogo.png';
 import SteamLogo from './images/steamLogo.png';
 import youTubeLogo from './images/youTubeLogo.png';
 import redditLogo from './images/redditLogo.png';
+import RankSelector from './RankSelector';
+import { GetBingoTileItems } from '../repositories/BingoItemRepository';
 
 class Table extends React.Component {
     constructor(props) {
@@ -19,19 +21,13 @@ class Table extends React.Component {
             addedTiles: [],
             useAdded: false,
             sleepAmt: 200,
+            selectedMaxLevel: 0
         }
+        this.rankSelected = this.rankSelected.bind(this);
     }
 
     loadText = () => {
-        var tileText = ["Get Asked to Sign Profile","Score a Hat Trick","Opponent has Anime PP","Someone Missed an Open Net","Toxicity in Chat", 
-                        "Pre-flip Goal","Low Five","Someone own Goals","Flip-Reset Goal","Opponent Using Weird Car", 
-                        "3 Minute Overtime","Passing Play Goal","Score a 0 Second Goal","Ceiling Shot","Opponent rage quit (ff)", 
-                        "Get into Rule #1","Fake an Opponent","Make an Epic Save","Musty Flick Goal","Demo Both Opponents (In succession)", 
-                        "Team Pinch Goal","Get a Lag Indicator","Double Tap Goal","Someone whiffs","Bump/Demo Goal", 
-                        "You Miss Boost", "Map is Salty Shores (day or night)", "Team Double Commits", "Opponents Double Commits", "Turtle Goal", 
-                        "Someone's using Poof Goal Explosion", "Get 3 Assists", "Get 3 Saves", "Have the Best Ping in Lobby", "Score 2 Goals in the first Minute",
-                        "Whiff a Flick"
-                        ];
+        var availableTiles = GetBingoTileItems(this.state.selectedMaxLevel);
 
         var usedIndex = [];
         var usedIndexLoad = [];
@@ -49,11 +45,11 @@ class Table extends React.Component {
         for (i=0; i<insertAmt; i++) {
             do
                     {
-                        var index = Math.floor(Math.random() * tileText.length);
+                        var index = Math.floor(Math.random() * availableTiles.length);
 
                     } while (usedIndexLoad.includes(index));
                     usedIndexLoad.push(index);
-                    tileArr.push(tileText[index]);
+                    tileArr.push(availableTiles[index]);
                     console.log(index)
         }
 
@@ -202,6 +198,9 @@ class Table extends React.Component {
         }
         this.forceUpdate();
     }
+    rankSelected(value) {
+        this.setState({ selectedMaxLevel: value });
+    }
 
     render () {
         let content, content2;
@@ -267,6 +266,7 @@ class Table extends React.Component {
             <React.Fragment>
                 <div style={leftDiv}>
                     <button onClick={this.loadText} >Create Board</button>
+                    <RankSelector onRankSelected={this.rankSelected} />
                     <h1>This is Rocket League Bingo!</h1>
                     
                     <div>

--- a/src/index.css
+++ b/src/index.css
@@ -94,8 +94,21 @@ th:hover {
   color: #cccccc;
 }
 
+select {
+  border-radius: 10px;
+  margin: 1vw;
+  background-color: transparent;
+  color: white;
+  font-size: 1vw;
+  border: 2px solid white;
+  transition: all .25s ease-in-out;
+}
 
-
+option {
+  font-size: 1vw;
+  color: black;
+  background-color: transparent;
+}
 
 
 /*--------------------------------------------

--- a/src/index.css
+++ b/src/index.css
@@ -102,6 +102,8 @@ select {
   font-size: 1vw;
   border: 2px solid white;
   transition: all .25s ease-in-out;
+  text-align: center;
+  text-align-last: center;
 }
 
 option {

--- a/src/repositories/BingoItemRepository.js
+++ b/src/repositories/BingoItemRepository.js
@@ -1,0 +1,48 @@
+const sharedItems = ["Score a Hat Trick","Opponent has Anime PP","Someone Missed an Open Net","Toxicity in Chat", 
+    "Pre-flip Goal","Low Five","Someone own Goals","Opponent Using Weird Car", "3 Minute Overtime","Score a 0 Second Goal",
+    "Opponent rage quit (ff)", "Get into Rule #1","Make an Epic Save", "Get a Lag Indicator","Someone whiffs","Bump/Demo Goal", 
+    "You Miss Boost", "Map is Salty Shores (day or night)", "Team Double Commits", "Opponents Double Commits", 
+    "Someone's using Poof Goal Explosion", "Have the Best Ping in Lobby", "Score 2 Goals in the first Minute", "Whiff a Flick"];
+
+const bronzeItems = [];
+
+const silverItems = ["Passing Play Goal", "Fake an Opponent", "Get 3 Assists", "Get 3 Saves"];
+
+const goldItems = ["Flip-Reset Goal", "Double Tap Goal"];
+
+const platinumItems = ["Turtle Goal"];
+
+const diamondItems = ["Ceiling Shot", "Musty Flick Goal"];
+
+const champItems = ["Demo Both Opponents (In succession)", "Team Pinch Goal"];
+
+const grandChampItems = ["High Five!"];
+
+const celebrityItems = ["Get Asked to Sign Profile"];
+
+const proItems = [];
+
+const itemsCollection = [
+    sharedItems,
+    bronzeItems,
+    silverItems,
+    goldItems,
+    platinumItems,
+    diamondItems,
+    champItems,
+    grandChampItems,
+    celebrityItems,
+    proItems
+]
+
+export function GetBingoTileItems(maxLevel) {
+    var items = [];
+    for(var i = 0; i <= maxLevel; i++) {
+        items = items.concat(itemsCollection[i]);
+    }
+    var iGotNothing = items.includes("");
+    if(iGotNothing) {
+        console.log('yea dude, i got nothing here');
+    }
+    return items;
+}

--- a/src/repositories/BingoItemRepository.js
+++ b/src/repositories/BingoItemRepository.js
@@ -40,9 +40,5 @@ export function GetBingoTileItems(maxLevel) {
     for(var i = 0; i <= maxLevel; i++) {
         items = items.concat(itemsCollection[i]);
     }
-    var iGotNothing = items.includes("");
-    if(iGotNothing) {
-        console.log('yea dude, i got nothing here');
-    }
     return items;
 }


### PR DESCRIPTION
This pull request adds a Rank Selector.

The Rank Selector filters the list of available bingo cards so users can adjust the difficulty level of their Bingo Board. 
The only new option this adds is "High Five!" as a Grand Champ and up difficulty Bingo Card.

![RankSelector](https://user-images.githubusercontent.com/2521937/83921583-a40eae00-a74c-11ea-93be-30646f1dbb1b.PNG)

The filtering works in a top down fashion. The items available to show up on the bingo card will consist of all options at or below the selected rank. Selecting "Pro" makes ALL challenges eligible to be on the bingo card. Selecting "Bronze" allows only Bronze level challenges and global challenges to appear. Selecting "Gold" allows global challenges, bronze challenges, silver challenges, and gold challenges to appear.